### PR TITLE
ChronoFormatter: Force Locale.US

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+.claude
 
 ### IntelliJ IDEA ###
 .idea/modules.xml

--- a/README.md
+++ b/README.md
@@ -98,16 +98,17 @@ To run the program with the downloaded CSV file, use the following options:
 ### Using the WordPress Output File
 
 To use the WordPress Output File, you must:
-1. Navigate to the `Member Archives 神道稲荷会メンバー用ビデオ` page in the editor.
-2. From the hamburger menu in the top-right, select `Code Editor`, revealing the underlying page HTML.
-3. Open the output HTML file in a text editor, and copy the **entire** contents of the file to the clipboard.
-4. In the WordPress Code Editor, paste the **entire** contents of the file into the main code box (DO NOT touch the page title box).
-5. Click `Exit code editor` in the top-right.
-6. From the `View` icon in the top right (loks like a stylized laptop), select `Preview in new tab`.
-7. Inspect the page in the new tab (e.g. check that all years are present and populated with the expected videos,
+1. Login to the Shrine WordPress site.
+2. Navigate to the `Member Archives 神道稲荷会メンバー用ビデオ` page in the editor.
+3. From the hamburger menu in the top-right, select `Code Editor`, revealing the underlying page HTML.
+4. Open the output HTML file in a text editor, and copy the **entire** contents of the file to the clipboard.
+5. In the WordPress Code Editor, paste the **entire** contents of the file into the main code box (DO NOT touch the page title box).
+6. Click `Exit code editor` in the top-right.
+7. From the `View` icon in the top right (loks like a stylized laptop), select `Preview in new tab`.
+8. Inspect the page in the new tab (e.g. check that all years are present and populated with the expected videos,
    and that vidoes are correctly linked to YouTube). 
-8. Close the preview tab.
-9. To publish: In the page editor tab, click the blue "Save" button in the top-right. **THIS WILL IMMEDIATELY PUBLISH THE PAGE**
+9. Close the preview tab.
+10. To publish: In the page editor tab, click the blue "Save" button in the top-right. **THIS WILL IMMEDIATELY PUBLISH THE PAGE**
 
 ## For Developers
 

--- a/src/main/kotlin/org/shintoinari/memberarchivegenerator/util/ChronoFormatter.kt
+++ b/src/main/kotlin/org/shintoinari/memberarchivegenerator/util/ChronoFormatter.kt
@@ -2,6 +2,7 @@ package org.shintoinari.memberarchivegenerator.util
 
 import java.time.format.DateTimeFormatter
 import java.time.temporal.TemporalAccessor
+import java.util.Locale
 
 /**
  * Interface for string formatters of temporal objects.
@@ -40,14 +41,14 @@ interface ChronoFormatter {
         /**
          * Constructs a ChronoFormatter for a given formatting pattern.
          */
-        fun ofPattern(pattern: String) =
-            invoke(DateTimeFormatter.ofPattern(pattern))
+        fun ofPattern(pattern: String, locale: Locale) =
+            ofPattern(pattern, locale) { it }
 
         /**
          * Constructs a ChronoFormatter for a given formatting pattern and an after-formatting lambda function.
          */
-        fun ofPattern(pattern: String, transform: (String) -> String) =
-            invoke(DateTimeFormatter.ofPattern(pattern), transform)
+        fun ofPattern(pattern: String, locale: Locale, transform: (String) -> String) =
+            invoke(DateTimeFormatter.ofPattern(pattern, locale), transform)
     }
 
 }
@@ -61,12 +62,12 @@ fun TemporalAccessor.format(formatter: ChronoFormatter) = formatter.format(this)
  * Constructs a ChronoFormatter for North American date formatting.
  */
 val ChronoFormatter.Companion.en: ChronoFormatter get() =
-    ChronoFormatter.ofPattern("LLLL d, yyyy")
+    ChronoFormatter.ofPattern("LLLL d, yyyy", Locale.US)
 
 /**
  * Constructs a ChronoFormatter for Japanese date formatting with full-width numeric characters.
  */
 val ChronoFormatter.Companion.jp: ChronoFormatter get() =
-    ChronoFormatter.ofPattern("yyyy年M月d日") {
+    ChronoFormatter.ofPattern("yyyy年M月d日", Locale.JAPAN) {
         it.toFullWidthNumeric()
     }

--- a/src/test/kotlin/org/shintoinari/memberarchivegenerator/util/ChronoFormatterTest.kt
+++ b/src/test/kotlin/org/shintoinari/memberarchivegenerator/util/ChronoFormatterTest.kt
@@ -8,6 +8,7 @@ import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 class ChronoFormatterTest : DescribeSpec({
 
@@ -57,7 +58,7 @@ class ChronoFormatterTest : DescribeSpec({
         describe("ofPattern(String)") {
 
             it("should create a ChronoFormatter from the provided pattern") {
-                val formatter = ChronoFormatter.ofPattern("yyyy-MM-dd")
+                val formatter = ChronoFormatter.ofPattern("yyyy-MM-dd", Locale.US)
                 val date = LocalDate.of(2024, 6, 15)
 
                 val result = formatter.format(date)
@@ -70,7 +71,7 @@ class ChronoFormatterTest : DescribeSpec({
         describe("ofPattern(String, transform)") {
 
             it("should create a ChronoFormatter from the pattern and apply the transform") {
-                val formatter = ChronoFormatter.ofPattern("yyyy-MM-dd") { "{$it}" }
+                val formatter = ChronoFormatter.ofPattern("yyyy-MM-dd", Locale.US) { "{$it}" }
                 val date = LocalDate.of(2024, 6, 15)
 
                 val result = formatter.format(date)
@@ -146,6 +147,18 @@ class ChronoFormatterTest : DescribeSpec({
             val result = offsetDateTime.format(ChronoFormatter.en)
 
             result shouldBe "March 7, 2024"
+        }
+
+        it("should format an OffsetDateTime in Norht American format even if JVM isn't") {
+            val defaultLocale = Locale.getDefault()
+            try {
+                Locale.setDefault(Locale.JAPAN)
+                val offsetDateTime = OffsetDateTime.of(2024, 3, 7, 14, 30, 45, 0, ZoneOffset.UTC)
+                val result = offsetDateTime.format(ChronoFormatter.en)
+                result shouldBe "March 7, 2024"
+            } finally {
+                Locale.setDefault(defaultLocale)
+            }
         }
 
     }


### PR DESCRIPTION
There was a bug where we didn't force Locale.US for the `ChronoFormatter.en` helper; the result is that when volunteers in other countries ran the CLI they'd get their localized month names, not the ones we need by our standard